### PR TITLE
Verify Tika resource enrichment through RX

### DIFF
--- a/tika-rx-module-test/.classpath
+++ b/tika-rx-module-test/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="Braintribe.ArtifactClasspathContainer"/>
+	<classpathentry kind="output" path="classes"/>
+</classpath>

--- a/tika-rx-module-test/.gitignore
+++ b/tika-rx-module-test/.gitignore
@@ -1,0 +1,5 @@
+/bin
+/build
+/classes
+/dist
+/out

--- a/tika-rx-module-test/.project
+++ b/tika-rx-module-test/.project
@@ -1,0 +1,14 @@
+<projectDescription>
+	<name>tika-rx-module-test - tribefire.extension.tika</name>
+	<comment/>
+	<projects/>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments/>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/tika-rx-module-test/build.xml
+++ b/tika-rx-module-test/build.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns:bt="antlib:com.braintribe.build.ant.tasks" basedir="." default="dist">
+	<bt:import artifact="com.braintribe.devrock.ant:unit-test-ant-script#1.0" useCase="DEVROCK" />
+</project>

--- a/tika-rx-module-test/class-gen/.gitignore
+++ b/tika-rx-module-test/class-gen/.gitignore
@@ -1,0 +1,2 @@
+/*
+!/.gitignore

--- a/tika-rx-module-test/pom.xml
+++ b/tika-rx-module-test/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>tribefire.extension.tika</groupId>
+        <artifactId>parent</artifactId>
+        <version>[1.0,1.1)</version>
+    </parent>
+    <artifactId>tika-rx-module-test</artifactId>
+    <version>1.0.1</version>
+    <properties>
+        <archetype>test</archetype>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>tribefire.extension.tika</groupId>
+            <artifactId>tika-rx-module</artifactId>
+            <version>${V.tribefire.extension.tika}</version>
+        </dependency>
+        <dependency>
+            <groupId>hiconic.platform.reflex</groupId>
+            <artifactId>smood-access-rx-module</artifactId>
+            <version>${V.hiconic.platform.reflex}</version>
+        </dependency>
+        <dependency>
+            <groupId>hiconic.platform.reflex</groupId>
+            <artifactId>reflex-test-commons</artifactId>
+            <version>${V.hiconic.platform.reflex}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/tika-rx-module-test/res/app/conf/access-configuration.yaml
+++ b/tika-rx-module-test/res/app/conf/access-configuration.yaml
@@ -1,0 +1,7 @@
+accesses:
+  - !hiconic.rx.access.smood.model.configuration.SmoodAccess
+    accessId: main-access
+    displayName: Tika RX Test Access
+    resourceStorageId: test-file-storage
+    dataModelNames:
+      - com.braintribe.gm:basic-resource-model

--- a/tika-rx-module-test/res/app/conf/resource-storage-configuration.yaml
+++ b/tika-rx-module-test/res/app/conf/resource-storage-configuration.yaml
@@ -1,0 +1,4 @@
+storages:
+  - !hiconic.rx.resource.model.configuration.FileSystemResourceStorage
+    storageId: test-file-storage
+    baseDir: out/resources

--- a/tika-rx-module-test/src/hiconic/rx/tika/test/TikaResourceEnrichingTest.java
+++ b/tika-rx-module-test/src/hiconic/rx/tika/test/TikaResourceEnrichingTest.java
@@ -1,0 +1,62 @@
+// ============================================================================
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+package hiconic.rx.tika.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+
+import org.junit.Test;
+
+import com.braintribe.model.processing.session.api.persistence.PersistenceGmSession;
+import com.braintribe.model.resource.Resource;
+import com.braintribe.model.resource.specification.RasterImageSpecification;
+
+import hiconic.rx.access.module.api.AccessContract;
+import hiconic.rx.test.common.AbstractRxTest;
+
+public class TikaResourceEnrichingTest extends AbstractRxTest {
+
+	@Test
+	public void detectsContentAndThenDerivesImageSpecification() throws IOException {
+		byte[] png = png(3, 2);
+		PersistenceGmSession session = resolveExportContract(AccessContract.class).systemSessionFactory().newSession("main-access");
+
+		Resource resource = session.resources().create() //
+				.name("deliberately-misleading.txt") //
+				.store(new ByteArrayInputStream(png));
+
+		assertThat(resource.getMimeType()).isEqualTo("image/png");
+		assertThat(resource.getFileSize()).isEqualTo((long) png.length);
+		assertThat(resource.getMd5()).isNotBlank();
+		assertThat(resource.getSpecification()).isInstanceOf(RasterImageSpecification.class);
+
+		RasterImageSpecification specification = (RasterImageSpecification) resource.getSpecification();
+		assertThat(specification.getPixelWidth()).isEqualTo(3);
+		assertThat(specification.getPixelHeight()).isEqualTo(2);
+	}
+
+	private static byte[] png(int width, int height) throws IOException {
+		BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		if (!ImageIO.write(image, "png", out))
+			throw new IllegalStateException("No PNG ImageIO writer available");
+		return out.toByteArray();
+	}
+}


### PR DESCRIPTION
Summary:
- add a real RX application test for Tika-backed resource enrichment
- upload a PNG with a deliberately misleading text filename
- verify detected MIME type, size, MD5 and raster image specification

Evidence:
- tika-rx-module-test: all tests successful
- test runs against the published Reflex MIME lifecycle fix from hiconic.platform.reflex PR 134
- git diff --check

The runtime Tika module already existed; this closes the missing integration proof rather than introducing a second enrichment implementation.